### PR TITLE
Try to work around new perms check

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,9 @@ EOF
 
   git config --global user.email "$GITBOT_EMAIL"
   git config --global user.name "$GITHUB_ACTOR"
+  # rf: https://github.com/actions/checkout/issues/760 this works around a new perms 
+  # check added for CVE-2022-24765
+  git config --global --add safe.directory /github/workspace
 }
 
 SOURCE_BRANCH="tmp-$(basename "${GITHUB_REF}")"


### PR DESCRIPTION
Ref: https://github.com/actions/checkout/issues/760
https://github.blog/2022-04-12-git-security-vulnerability-announced/

This new check was added due to that security vuln. It causes actions to fail like this:
https://github.com/OdenTech/cloudfunctions/actions/runs/2223380539
```
+ git checkout -b tmp-develop 07c4515c3b0b02993c2dded7695e970466129316
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```